### PR TITLE
implemented Initializer using `PartialKeyPath`

### DIFF
--- a/Sources/KeyPathValue/ReferenceWritableKeyPathWithValue.swift
+++ b/Sources/KeyPathValue/ReferenceWritableKeyPathWithValue.swift
@@ -18,11 +18,21 @@ public struct ReferenceWritableKeyPathWithValue<Root: AnyObject> {
     /// assign value
     public let apply: (Root) -> Void
 
-    /// initialize with keyPath and value
+    /// initialize with reference writable keyPath and value
     public init<Value>(_ keyPath: ReferenceWritableKeyPath<Root, Value>, _ value: Value) {
         self.keyPath = keyPath
         self.value = value
         self.apply = { $0[keyPath: keyPath] = value }
+    }
+
+    /// initialize with partial keyPath and value
+    @_disfavoredOverload
+    public init?<Value>(_ keyPath: PartialKeyPath<Root>, _ value: Value) {
+        guard let keyPath = keyPath as? ReferenceWritableKeyPath<Root, Value> else {
+            return nil
+        }
+
+        self.init(keyPath, value)
     }
 }
 

--- a/Sources/KeyPathValue/WritableKeyPathWithValue.swift
+++ b/Sources/KeyPathValue/WritableKeyPathWithValue.swift
@@ -18,11 +18,21 @@ public struct WritableKeyPathWithValue<Root> {
     /// assign value
     public let apply: (inout Root) -> Void
 
-    /// initialize with keyPath and value
+    /// initialize with writable keyPath and value
     public init<Value>(_ keyPath: WritableKeyPath<Root, Value>, _ value: Value) {
         self.keyPath = keyPath
         self.value = value
         self.apply = { $0[keyPath: keyPath] = value }
+    }
+
+    /// initialize with partial keyPath and value
+    @_disfavoredOverload
+    public init?<Value>(_ keyPath: PartialKeyPath<Root>, _ value: Value) {
+        guard let keyPath = keyPath as? WritableKeyPath<Root, Value> else {
+            return nil
+        }
+
+        self.init(keyPath, value)
     }
 }
 


### PR DESCRIPTION
If parameter is marked with `private(set)`, WritableKeyPath cannot be returned.　
Therefore, partialKeyPath can be used to initialize it.

It can be used as follows.

```swift
struct Item {
    private(set) var text: String

    init(text: String) {
        self.text = text
    }
}

var item = Item(text: "")

let keyPathWithValue = WritableKeyPathWithValue(\Item.text, "hello")

keyPathWithValue?.apply(&item)

print(item) // -> Item(text: "hello")
```