### PR TITLE
returns whether the value was successfully applied or not

### DIFF
--- a/Sources/KeyPathValue/ReferenceWritableKeyPathValueApplier.swift
+++ b/Sources/KeyPathValue/ReferenceWritableKeyPathValueApplier.swift
@@ -14,14 +14,25 @@ public struct ReferenceWritableKeyPathValueApplier<Root: AnyObject> {
     /// KeyPath to which you want to assign a value
     public let keyPath: PartialKeyPath<Root>
     /// assign value
-    public let apply: (Any, Root) -> Void
+    public let _apply: (Any, Root) -> Bool
 
     /// initialize with keyPath
     public init<Value>(_ keyPath: ReferenceWritableKeyPath<Root,Value>) {
         self.keyPath = keyPath
-        self.apply = {
-            guard let value = $0 as? Value else { return }
+        self._apply = {
+            guard let value = $0 as? Value else { return false }
             $1[keyPath: keyPath] = value
+            return true
         }
+    }
+
+    /// assign value
+    /// - Parameters:
+    ///   - value: value to be assigned
+    ///   - target: assign target
+    /// - Returns: whether the assignment was successful or not. (type casting)
+    @discardableResult
+    public func apply(_ value: Any, to target: Root) -> Bool {
+        _apply(value, target)
     }
 }

--- a/Sources/KeyPathValue/ReferenceWritableKeyPathWithValue.swift
+++ b/Sources/KeyPathValue/ReferenceWritableKeyPathWithValue.swift
@@ -16,13 +16,13 @@ public struct ReferenceWritableKeyPathWithValue<Root: AnyObject> {
     /// Value to be assigned
     public let value: Any
     /// assign value
-    public let apply: (Root) -> Void
+    public let _apply: (Root) -> Void
 
     /// initialize with reference writable keyPath and value
     public init<Value>(_ keyPath: ReferenceWritableKeyPath<Root, Value>, _ value: Value) {
         self.keyPath = keyPath
         self.value = value
-        self.apply = { $0[keyPath: keyPath] = value }
+        self._apply = { $0[keyPath: keyPath] = value }
     }
 
     /// initialize with partial keyPath and value
@@ -34,14 +34,19 @@ public struct ReferenceWritableKeyPathWithValue<Root: AnyObject> {
 
         self.init(keyPath, value)
     }
+
+    /// assign value
+    public func apply(to target: Root) {
+        _apply(target)
+    }
 }
 
 extension ReferenceWritableKeyPathWithValue {
     public init(_ keyValueApplier: ReferenceWritableKeyPathValueApplier<Root>, value: Any) {
         self.keyPath = keyValueApplier.keyPath
         self.value = value
-        self.apply = {
-            keyValueApplier.apply(value, $0)
+        self._apply = {
+            keyValueApplier.apply(value, to: $0)
         }
     }
 }

--- a/Sources/KeyPathValue/WritableKeyPathValueApplier.swift
+++ b/Sources/KeyPathValue/WritableKeyPathValueApplier.swift
@@ -14,14 +14,25 @@ public struct WritableKeyPathValueApplier<Root> {
     /// KeyPath to which you want to assign a value
     public let keyPath: PartialKeyPath<Root>
     /// assign value
-    public let apply: (Any, inout Root) -> Void
+    private let _apply: (Any, inout Root) -> Bool
 
     /// initialize with keyPath
     public init<Value>(_ keyPath: WritableKeyPath<Root,Value>) {
         self.keyPath = keyPath
-        self.apply = {
-            guard let value = $0 as? Value else { return }
+        self._apply = {
+            guard let value = $0 as? Value else { return false }
             $1[keyPath: keyPath] = value
+            return true
         }
+    }
+
+    /// assign value
+    /// - Parameters:
+    ///   - value: value to be assigned
+    ///   - target: assign target
+    /// - Returns: whether the assignment was successful or not. (type casting)
+    @discardableResult
+    public func apply(_ value: Any, to target: inout Root) -> Bool {
+        _apply(value, &target)
     }
 }

--- a/Sources/KeyPathValue/WritableKeyPathWithValue.swift
+++ b/Sources/KeyPathValue/WritableKeyPathWithValue.swift
@@ -16,13 +16,13 @@ public struct WritableKeyPathWithValue<Root> {
     /// Value to be assigned
     public let value: Any
     /// assign value
-    public let apply: (inout Root) -> Void
+    public let _apply: (inout Root) -> Void
 
     /// initialize with writable keyPath and value
     public init<Value>(_ keyPath: WritableKeyPath<Root, Value>, _ value: Value) {
         self.keyPath = keyPath
         self.value = value
-        self.apply = { $0[keyPath: keyPath] = value }
+        self._apply = { $0[keyPath: keyPath] = value }
     }
 
     /// initialize with partial keyPath and value
@@ -34,14 +34,19 @@ public struct WritableKeyPathWithValue<Root> {
 
         self.init(keyPath, value)
     }
+
+    /// assign value
+    public func apply(to target: inout Root) {
+        _apply(&target)
+    }
 }
 
 extension WritableKeyPathWithValue {
     public init(_ keyValueApplier: WritableKeyPathValueApplier<Root>, value: Any) {
         self.keyPath = keyValueApplier.keyPath
         self.value = value
-        self.apply = {
-            keyValueApplier.apply(value, &$0)
+        self._apply = {
+            keyValueApplier.apply(value, to: &$0)
         }
     }
 }

--- a/Tests/KeyPathValueTests/KeyPathValueApplierTests.swift
+++ b/Tests/KeyPathValueTests/KeyPathValueApplierTests.swift
@@ -21,27 +21,52 @@ final class KeyPathValueApplierTests: XCTestCase {
 
     func testWritableKeyPathValueApplier() {
         var applier: WritableKeyPathValueApplier<StructItem>
+        var isSucceeded: Bool
 
         applier = .init(\.number)
-        applier.apply(123, to: &structItem)
+        isSucceeded = applier.apply(123, to: &structItem)
+        XCTAssertTrue(isSucceeded)
 
         applier = .init(\.object)
-        applier.apply(Object(string: "123"), to: &structItem)
+        isSucceeded = applier.apply(Object(string: "123"), to: &structItem)
+        XCTAssertTrue(isSucceeded)
 
         XCTAssertEqual(structItem.number, 123)
         XCTAssertEqual(structItem.object, .init(string: "123"))
+
+        // fails
+        applier = .init(\.number)
+        isSucceeded = applier.apply("123", to: &structItem)
+        XCTAssertFalse(isSucceeded)
+
+        applier = .init(\.object)
+        isSucceeded = applier.apply("123", to: &structItem)
+        XCTAssertFalse(isSucceeded)
     }
 
     func testReferenceWritableKeyPathValueApplier() {
         var applier: ReferenceWritableKeyPathValueApplier<ClassItem>
+        var isSucceeded: Bool
 
         applier = .init(\.number)
-        applier.apply(123, to: classItem)
+        isSucceeded = applier.apply(123, to: classItem)
+        XCTAssertTrue(isSucceeded)
 
         applier = .init(\.object)
-        applier.apply(Object(string: "123"), to: classItem)
+        isSucceeded = applier.apply(Object(string: "123"), to: classItem)
+        XCTAssertTrue(isSucceeded)
 
         XCTAssertEqual(classItem.number, 123)
         XCTAssertEqual(classItem.object, .init(string: "123"))
+
+
+        // fails
+        applier = .init(\.number)
+        isSucceeded = applier.apply("123", to: classItem)
+        XCTAssertFalse(isSucceeded)
+
+        applier = .init(\.object)
+        isSucceeded = applier.apply("123", to: classItem)
+        XCTAssertFalse(isSucceeded)
     }
 }

--- a/Tests/KeyPathValueTests/KeyPathValueApplierTests.swift
+++ b/Tests/KeyPathValueTests/KeyPathValueApplierTests.swift
@@ -23,10 +23,10 @@ final class KeyPathValueApplierTests: XCTestCase {
         var applier: WritableKeyPathValueApplier<StructItem>
 
         applier = .init(\.number)
-        applier.apply(123, &structItem)
+        applier.apply(123, to: &structItem)
 
         applier = .init(\.object)
-        applier.apply(Object(string: "123"), &structItem)
+        applier.apply(Object(string: "123"), to: &structItem)
 
         XCTAssertEqual(structItem.number, 123)
         XCTAssertEqual(structItem.object, .init(string: "123"))
@@ -36,10 +36,10 @@ final class KeyPathValueApplierTests: XCTestCase {
         var applier: ReferenceWritableKeyPathValueApplier<ClassItem>
 
         applier = .init(\.number)
-        applier.apply(123, classItem)
+        applier.apply(123, to: classItem)
 
         applier = .init(\.object)
-        applier.apply(Object(string: "123"), classItem)
+        applier.apply(Object(string: "123"), to: classItem)
 
         XCTAssertEqual(classItem.number, 123)
         XCTAssertEqual(classItem.object, .init(string: "123"))

--- a/Tests/KeyPathValueTests/KeyPathWithValueTests.swift
+++ b/Tests/KeyPathValueTests/KeyPathWithValueTests.swift
@@ -18,7 +18,7 @@ final class KeyPathWithValueTests: XCTestCase {
         ]
 
         appliers.forEach { applier in
-            applier.apply(&structItem)
+            applier.apply(to: &structItem)
         }
 
         XCTAssertEqual(structItem.number, 123)
@@ -32,7 +32,7 @@ final class KeyPathWithValueTests: XCTestCase {
         ]
 
         appliers.forEach { applier in
-            applier.apply(classItem)
+            applier.apply(to: classItem)
         }
 
         XCTAssertEqual(classItem.number, 123)
@@ -42,7 +42,7 @@ final class KeyPathWithValueTests: XCTestCase {
     func testWritableKeyPathWithValuePrivateSet() {
         let applier = WritableKeyPathWithValue<StructItem>(\.privateSetProperty, 123.0)
 
-        applier?.apply(&structItem)
+        applier?.apply(to: &structItem)
 
         XCTAssertEqual(structItem.privateSetProperty, 123.0)
     }
@@ -50,7 +50,7 @@ final class KeyPathWithValueTests: XCTestCase {
     func testReferenceWritableKeyPathWithValuePrivateSet() {
         let applier = ReferenceWritableKeyPathWithValue<ClassItem>(\.privateSetProperty, 123.0)
 
-        applier?.apply(classItem)
+        applier?.apply(to: classItem)
 
         XCTAssertEqual(classItem.privateSetProperty, 123.0)
     }


### PR DESCRIPTION
The apply method of KeyPathApplier has an argument of type Any.
Therefore, cast is performed when assigning a value, and if it does not succeed, the assignment fails.

```swift
let applier = WritableKeyPathValueApplier<StructItem>(\.number)
let isSucceeded =  applier.apply("AA", to: &structItem) // -> false
```